### PR TITLE
bulk_update rake task

### DIFF
--- a/lib/fuzzily.rb
+++ b/lib/fuzzily.rb
@@ -4,4 +4,11 @@ require "fuzzily/migration"
 require "fuzzily/model"
 require "active_record"
 
+begin
+  gem "rails", ">=3.0"
+  require "tasks/tasks"
+rescue Gem::LoadError
+  # rails not available
+end
+
 ActiveRecord::Base.extend(Fuzzily::Searchable)

--- a/lib/tasks/bulk_update.rake
+++ b/lib/tasks/bulk_update.rake
@@ -1,0 +1,25 @@
+namespace :fuzzily do
+
+  task bulk_update: :environment do
+    Rails.application.eager_load!
+
+    models = ActiveRecord::Base.descendants
+
+    selected_models = ENV['MODELS'] && ENV['MODELS'].split(',')
+    selected_methods = ENV['FIELDS'] && ENV['FIELDS'].split(',').map{|f| "bulk_update_fuzzy_"+f}
+
+    models.select!{|model| selected_models.include? model.to_s} if selected_models
+
+    models.each do |model|
+      if selected_methods
+        @methods = selected_methods & model.methods.map(&:to_s)
+      else
+        @methods = model.methods.grep(/bulk_update_fuzzy/)
+      end
+      @methods.each do |method|
+        puts "Running #{model}\##{method}"
+        model.send method
+      end
+    end
+  end
+end

--- a/lib/tasks/tasks.rb
+++ b/lib/tasks/tasks.rb
@@ -1,0 +1,8 @@
+require 'rails'
+
+#for Rails integration
+class Tasks < Rails::Railtie
+  rake_tasks do
+    Dir[File.join(File.dirname(__FILE__),'*.rake')].each { |f| load f }
+  end
+end


### PR DESCRIPTION
Added a rake task that automatically runs the `bulk_update` method for any models with `fuzzily_searchable` fields.  

The task will run on all models by default, but its scope can be limited by optional `MODELS=` and `FIELDS=` command-line arguments.

If this looks good, I'll add documentation to the readme.