### PR TITLE
Update searchable.rb

### DIFF
--- a/lib/fuzzily/searchable.rb
+++ b/lib/fuzzily/searchable.rb
@@ -22,7 +22,7 @@ module Fuzzily
         cfo=self.send(_o.trigram_association).new
         cfo.score = score
         cfo.trigram = trigram
-        cfo.owner_type = owner_type
+        cfo.owner_type = self.class.name
         cfo.save!
       end
     end


### PR DESCRIPTION
Updates of fuzzily searchable objects cause Rails exceptions due to mass assignment of attributes from fuzzily
