### PR TITLE
Nil limit

### DIFF
--- a/lib/fuzzily/searchable.rb
+++ b/lib/fuzzily/searchable.rb
@@ -40,7 +40,7 @@ module Fuzzily
       private
 
       def _find_by_fuzzy(_o, pattern, options={})
-        options[:limit] ||= 10
+        options[:limit] ||= 10 unless options.has_key? :limit
         options[:offset] ||= 0
 
         trigrams = _o.trigram_class_name.constantize.

--- a/spec/fuzzily/searchable_spec.rb
+++ b/spec/fuzzily/searchable_spec.rb
@@ -154,6 +154,18 @@ describe Fuzzily::Searchable do
         subject.find_by_fuzzy_name('Paris', :limit => 2).length.should == 2
       end
 
+      it 'limits results to 10 if limit option is not given' do
+        subject.fuzzily_searchable :name
+        30.times { subject.create!(:name => 'Paris') }
+        subject.find_by_fuzzy_name('Paris').length.should == 10
+      end
+
+      it 'does not limit results it limit option is present and is nil' do
+        subject.fuzzily_searchable :name
+        30.times { subject.create!(:name => 'Paris') }
+        subject.find_by_fuzzy_name('Paris', :limit => nil).length.should == 30
+      end
+
       it 'honours offset option' do
         subject.fuzzily_searchable :name
         3.times { subject.create!(:name => 'Paris') }


### PR DESCRIPTION
While I agree that 10 is a sensible default limit for the results considering the usage of this gem through AJAX, it currently lacks a way to simply disable this limit. This is useful in cases where you want to implement pagination, for example.

This PR changes find_by_fuzzy methods to honour the nil limit when it is expressively given in the options.

I also added a spec for this aswell as for the default limit size.