### PR TITLE
Update readme to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ class MyStuff < ActiveRecord::Base
 end
 ```
 
+*Note: The `name` part in the following method calls refers to the `:name` field. Replace it to match your searchable attribute.*
+
 Index your model (will happen automatically for new/updated records):
 
 ```ruby


### PR DESCRIPTION
The readme doesn't mention that presented method names are dynamic and depend on the `fuzzily_searchable` attribute. It can cause confusion and `undefined method` errors. (example: http://stackoverflow.com/questions/29758059/fuzzily-cannot-get-it-to-work)