### PR TITLE
Fix AR::RecordNotFound being raised with missing objects.

### DIFF
--- a/lib/fuzzily/searchable.rb
+++ b/lib/fuzzily/searchable.rb
@@ -51,12 +51,12 @@ module Fuzzily
           matches_for(pattern)
         records = _load_for_ids(trigrams.map(&:owner_id))
         # order records as per trigram query (no portable way to do this in SQL)
-        trigrams.map { |t| records[t.owner_id] }
+        trigrams.map { |t| records[t.owner_id] }.compact
       end
 
       def _load_for_ids(ids)
         {}.tap do |result|
-          find(ids).each { |_r| result[_r.id] = _r }
+          where(:id => ids).each { |_r| result[_r.id] = _r }
         end
       end
 
@@ -136,7 +136,7 @@ module Fuzzily
 
         after_save do |record|
           next unless record.send("#{field}_changed?".to_sym)
-          
+
           record.send(_o.update_trigrams_method)
         end
 

--- a/lib/fuzzily/searchable.rb
+++ b/lib/fuzzily/searchable.rb
@@ -56,7 +56,12 @@ module Fuzzily
 
       def _load_for_ids(ids)
         {}.tap do |result|
-          where(:id => ids).each { |_r| result[_r.id] = _r }
+          results = if respond_to? :where
+            where(:id => ids)
+          else
+            find(:all, ids)
+          end
+          results.each { |_r| result[_r.id] = _r }
         end
       end
 

--- a/spec/fuzzily/searchable_spec.rb
+++ b/spec/fuzzily/searchable_spec.rb
@@ -12,7 +12,7 @@ describe Fuzzily::Searchable do
   before(:each) { prepare_trigrams_table }
   before(:each) { prepare_owners_table   }
 
-  subject do 
+  subject do
     silence_warnings do
       Stuff = Class.new(ActiveRecord::Base)
     end
@@ -73,7 +73,7 @@ describe Fuzzily::Searchable do
     before do
       subject.fuzzily_searchable :name
     end
-    
+
     it 're-creates trigrams' do
       subject.create!(:name => 'Paris')
       old_ids = Trigram.all.map(&:id)
@@ -170,6 +170,20 @@ describe Fuzzily::Searchable do
         subject.fuzzily_searchable :name
         3.times { subject.create!(:name => 'Paris') }
         subject.find_by_fuzzy_name('Paris', :offset => 2).length.should == 1
+      end
+
+      it 'does not raise on missing objects' do
+        subject.fuzzily_searchable :name
+        belgium = subject.create(:name => 'Belgium')
+        belgium.delete
+        subject.find_by_fuzzy_name('Belgium')
+      end
+
+      it 'finds others alongside missing' do
+        subject.fuzzily_searchable :name
+        belgium1, belgium2 = 2.times.map { subject.create(:name => 'Belgium') }
+        belgium1.delete
+        subject.find_by_fuzzy_name('Belgium').should ==  [belgium2]
       end
     end
   end


### PR DESCRIPTION
> The use of ActiveRecord's #find meant missing IDs raised AR::RecordNotFound. This might come up if an object was created and then deleted without its trigram data also being deleted. To avoid the exception this uses #where instead of #find which will ignore missing results.
> 
> Due to the method with which the records are sorted to match the trigram query, in these cases nils were cropping up in the results, so this uses #compact to just return the records.
> 
> The first test case ensures no exceptions for missing objects are raised. The second test case ensures the fuzzy find still works and that no nils are returned.

---

Excuse the whitespace removal, that was done automatically. Let me know if you want a rebased version without that.
