### PR TITLE
to string Fuzzily::String to fix force_encoding error

### DIFF
--- a/lib/fuzzily/trigram.rb
+++ b/lib/fuzzily/trigram.rb
@@ -19,7 +19,7 @@ module Fuzzily
     # Remove accents, downcase, replace spaces and word start with '*',
     # return list of normalized words
     def normalize
-      ActiveSupport::Multibyte::Chars.new(self).
+      ActiveSupport::Multibyte::Chars.new(self.to_s).
         mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/,'').downcase.to_s.
         gsub(/[^a-z]/,' ').
         gsub(/\s+/,'*').


### PR DESCRIPTION
had a "undefined method 'force_encoding' for <Fuzzily::String> in trigram.rb.

just forced fuzzily::string to be a string with to_s